### PR TITLE
Cb fix report

### DIFF
--- a/src/Models/BaseClasses/Animal.cs
+++ b/src/Models/BaseClasses/Animal.cs
@@ -22,7 +22,7 @@ namespace Trestlebridge.Models
         public string Type
         {
             set { _type = value; }
-            get { return Type; }
+            get { return _type; }
         }
         public string ShortId
         {
@@ -32,7 +32,7 @@ namespace Trestlebridge.Models
         // Methods:
         public override string ToString()
         {
-            return $"Type:{Type} - ID:{this._shortId}";
+            return $"Type: {Type}  - ID: {ShortId} ";
         }
     }
 }

--- a/src/Models/Farm.cs
+++ b/src/Models/Farm.cs
@@ -57,10 +57,10 @@ namespace Trestlebridge.Models
             StringBuilder report = new StringBuilder();
 
             GrazingFields.ForEach(gf => report.Append(gf));
-            // PlowedFields.ForEach(pf => report.Append(pf));
-            // NaturalFields.ForEach(nf => report.Append(nf));
-            // ChickenHouses.ForEach(ch => report.Append(ch));
-            // DuckHouses.ForEach(dh => report.Append(dh));
+            PlowedFields.ForEach(pf => report.Append(pf));
+            NaturalFields.ForEach(nf => report.Append(nf));
+            ChickenHouses.ForEach(ch => report.Append(ch));
+            DuckHouses.ForEach(dh => report.Append(dh));
 
             return report.ToString();
         }

--- a/src/Models/Farm.cs
+++ b/src/Models/Farm.cs
@@ -57,10 +57,10 @@ namespace Trestlebridge.Models
             StringBuilder report = new StringBuilder();
 
             GrazingFields.ForEach(gf => report.Append(gf));
-            PlowedFields.ForEach(pf => report.Append(pf));
-            NaturalFields.ForEach(nf => report.Append(nf));
-            ChickenHouses.ForEach(ch => report.Append(ch));
-            DuckHouses.ForEach(dh => report.Append(dh));
+            // PlowedFields.ForEach(pf => report.Append(pf));
+            // NaturalFields.ForEach(nf => report.Append(nf));
+            // ChickenHouses.ForEach(ch => report.Append(ch));
+            // DuckHouses.ForEach(dh => report.Append(dh));
 
             return report.ToString();
         }


### PR DESCRIPTION
Fixes
- When running the farm report, animals are displayed inside of their facility with their type and id

Changes proposed in this request:
- N/A

Commit message: Animals displayed with type and ID in farm report

@gregarious-goats
