### PR TITLE
recall the collectinput method for excess seeds..

### DIFF
--- a/src/Actions/ChooseBothFields.cs
+++ b/src/Actions/ChooseBothFields.cs
@@ -64,7 +64,7 @@ namespace Trestlebridge.Actions {
                 Console.WriteLine ();
 
                 // How can I output the type of animal chosen here?
-                Console.WriteLine ($"Where would you like to plant the {seeds[0].Type}?");
+                Console.WriteLine ($"Where would you like to plant {seeds.Count} {seeds[0].Type} seeds?");
 
                 Console.Write ("> ");
 
@@ -73,12 +73,12 @@ namespace Trestlebridge.Actions {
                 if(choice < farm.NaturalFields.Count)
                 {
                     List<INaturalFieldDwelling> seed = seeds.Cast<INaturalFieldDwelling>().ToList();
-                    farm.NaturalFields[choice].AddResource( seed);
+                    farm.NaturalFields[choice].AddResource(farm, seed);
                 }
                 else
                 {
                     List<IPlowedFieldDwelling> seed = seeds.Cast<IPlowedFieldDwelling>().ToList();
-                    farm.PlowedFields[choice-farm.NaturalFields.Count].AddResource(seed);
+                    farm.PlowedFields[choice-farm.NaturalFields.Count].AddResource(farm, seed);
                 }
 
                 /*

--- a/src/Actions/ChooseNaturalField.cs
+++ b/src/Actions/ChooseNaturalField.cs
@@ -51,12 +51,12 @@ namespace Trestlebridge.Actions {
                 Console.WriteLine ();
 
                 // How can I output the type of animal chosen here?
-                Console.WriteLine ($"Where would you like to plant the {seeds[0].Type}?");
+                Console.WriteLine ($"Where would you like to plant {seeds.Count} {seeds[0].Type} seeds?");
 
                 Console.Write ("> ");
                 int choice = Int32.Parse(Console.ReadLine ());
 
-                farm.NaturalFields[choice-1].AddResource(seeds);
+                farm.NaturalFields[choice-1].AddResource(farm, seeds);
 
                 /*
                     Couldn't get this to work. Can you?

--- a/src/Actions/ChoosePlowedFiled.cs
+++ b/src/Actions/ChoosePlowedFiled.cs
@@ -49,12 +49,12 @@ namespace Trestlebridge.Actions {
             Console.WriteLine ();
 
             // How can I output the type of animal chosen here?
-            Console.WriteLine ($"Where would you like to plant the {seeds[0].Type}?");
+            Console.WriteLine ($"Where would you like to plant {seeds.Count} {seeds[0].Type} seeds?");
 
             Console.Write ("> ");
             int choice = Int32.Parse(Console.ReadLine ());
 
-            farm.PlowedFields[choice-1].AddResource(seeds);
+            farm.PlowedFields[choice-1].AddResource(farm, seeds);
 
             /*
                 Couldn't get this to work. Can you?

--- a/src/Interfaces/IFacility.cs
+++ b/src/Interfaces/IFacility.cs
@@ -9,6 +9,6 @@ namespace Trestlebridge.Interfaces
         double Capacity { get; }
 
         void AddResource (Farm farm, T resource);
-        void AddResource (List<T> resources);
+        void AddResource (Farm farm, List<T> resources);
     }
 }

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -30,7 +30,7 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (List<IHouseDwelling> animals)
+        public void AddResource (Farm farm, List<IHouseDwelling> animals)
         {
             if (_animals.Count + animals.Count <= _capacity) {
                 _animals.AddRange(animals);

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -32,7 +32,7 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (List<IHouseDwelling> animals)
+        public void AddResource (Farm farm, List<IHouseDwelling> animals)
         {
             if (_animals.Count + animals.Count <= _capacity) {
                 _animals.AddRange(animals);

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -31,7 +31,7 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (List<IGrazing> animals)
+        public void AddResource (Farm farm, List<IGrazing> animals)
         {
             if (_animals.Count + animals.Count <= _capacity) {
                 _animals.AddRange(animals);

--- a/src/Models/Facilities/NaturalField.cs
+++ b/src/Models/Facilities/NaturalField.cs
@@ -30,10 +30,18 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (List<INaturalFieldDwelling> plants)
+        public void AddResource (Farm farm, List<INaturalFieldDwelling> plants)
         {
             if (_plants.Count + plants.Count <= _capacity) {
                 _plants.AddRange(plants);
+            }
+            else {
+                for (int i =  _plants.Count; i < _capacity; i++)
+                {
+                    _plants.Add(plants[0]);
+                    plants.Remove(plants[0]);
+                }
+                ChooseNaturalField.CollectInput(farm, plants);
             }
         }
 

--- a/src/Models/Facilities/PlowedField.cs
+++ b/src/Models/Facilities/PlowedField.cs
@@ -30,14 +30,22 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (List<IPlowedFieldDwelling> plants)
+        public void AddResource (Farm farm, List<IPlowedFieldDwelling> plants)
         {
             if (_plants.Count + plants.Count <= _capacity) {
                 _plants.AddRange(plants);
             }
-            else
-            {
-                
+            else {
+                for (int i =  _plants.Count; i < _capacity; i++)
+                {
+                    _plants.Add(plants[0]);
+                    plants.Remove(plants[0]);
+                }
+                //if(plants[0].Type == "SunFlower")
+
+                //     ChooseBothField.CollectInput(farm,plants);
+                // else
+                    ChoosePlowedField.CollectInput(farm, plants);
             }
         }
 

--- a/src/Models/Facilities/PlowedField.cs
+++ b/src/Models/Facilities/PlowedField.cs
@@ -42,7 +42,6 @@ namespace Trestlebridge.Models.Facilities {
                     plants.Remove(plants[0]);
                 }
                 //if(plants[0].Type == "SunFlower")
-
                 //     ChooseBothField.CollectInput(farm,plants);
                 // else
                     ChoosePlowedField.CollectInput(farm, plants);


### PR DESCRIPTION
Fixes
- when there is an excess amount of seeds than the capacity of the field then first it fills that row and then gives choice to choose another field.
-
-

Changes proposed in this request:
-
-
-

Commit message:

@gregarious-goats
